### PR TITLE
Fix FONT_HERSHEY_PLAIN error in 2.0.2

### DIFF
--- a/CameraImageToMatSample.cs
+++ b/CameraImageToMatSample.cs
@@ -50,7 +50,7 @@ public class CameraImageToMatSample : MonoBehaviour
 			
 			inputMat.put (0, 0, image.Pixels);
 
-			Imgproc.putText (inputMat, "CameraImageToMatSample " + inputMat.cols () + "x" + inputMat.rows (), new Point (5, inputMat.rows () - 5), Imgproc.FONT_HERSHEY_PLAIN, 1.0, new Scalar (255, 0, 0, 255));
+			Imgproc.putText (inputMat, "CameraImageToMatSample " + inputMat.cols () + "x" + inputMat.rows (), new Point (5, inputMat.rows () - 5), Core.FONT_HERSHEY_PLAIN, 1.0, new Scalar (255, 0, 0, 255));
 			
 			
 			if (outputTexture == null) {

--- a/PostRenderToMatSample.cs
+++ b/PostRenderToMatSample.cs
@@ -79,19 +79,19 @@ public class PostRenderToMatSample : MonoBehaviour
 
 		if (mode == modeType.original) {
 			
-			Imgproc.putText (cameraMat, "ORIGINAL MODE " + cameraTexture.width + "x" + cameraTexture.height, new Point (5, cameraTexture.height - 5), Imgproc.FONT_HERSHEY_PLAIN, 1.0, new Scalar (255, 0, 0, 255));	
+			Imgproc.putText (cameraMat, "ORIGINAL MODE " + cameraTexture.width + "x" + cameraTexture.height, new Point (5, cameraTexture.height - 5), Core.FONT_HERSHEY_PLAIN, 1.0, new Scalar (255, 0, 0, 255));	
 			
 		} else if (mode == modeType.sepia) {
 
 			Core.transform (cameraMat, cameraMat, mSepiaKernel);
 
-			Imgproc.putText (cameraMat, "SEPIA MODE " + cameraTexture.width + "x" + cameraTexture.height, new Point (5, cameraTexture.height - 5), Imgproc.FONT_HERSHEY_PLAIN, 1.0, new Scalar (255, 0, 0, 255));
+			Imgproc.putText (cameraMat, "SEPIA MODE " + cameraTexture.width + "x" + cameraTexture.height, new Point (5, cameraTexture.height - 5), Core.FONT_HERSHEY_PLAIN, 1.0, new Scalar (255, 0, 0, 255));
 
 		} else if (mode == modeType.pixelize) {
 			Imgproc.resize (cameraMat, mIntermediateMat, mSize0, 0.2, 0.2, Imgproc.INTER_NEAREST);
 			Imgproc.resize (mIntermediateMat, cameraMat, cameraMat.size (), 0.0, 0.0, Imgproc.INTER_NEAREST);
 
-			Imgproc.putText (cameraMat, "PIXELIZE MODE" + cameraTexture.width + "x" + cameraTexture.height, new Point (5, cameraTexture.height - 5), Imgproc.FONT_HERSHEY_PLAIN, 1.0, new Scalar (255, 0, 0, 255));
+			Imgproc.putText (cameraMat, "PIXELIZE MODE" + cameraTexture.width + "x" + cameraTexture.height, new Point (5, cameraTexture.height - 5), Core.FONT_HERSHEY_PLAIN, 1.0, new Scalar (255, 0, 0, 255));
 
 		}
 				


### PR DESCRIPTION
Hi, I have installed 2.0.2 and try to run the sample code.

I found that FONT_HERSHEY_PLAIN is not in Imgproc now, and it has beed moved to Core, so should change from `Imgproc.FONT_HERSHEY_PLAIN` to `Core.FONT_HERSHEY_PLAIN`.